### PR TITLE
Pin GitHub Actions to Ubuntu 24.04

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,8 +6,6 @@
     ":semanticCommitTypeAll(chore)",
     ":semanticCommitScope(deps)",
     ":separateMajorReleases",
-    "helpers:pinGitHubActionDigests",
-    "docker:pinDigests",
     "security:openssf-scorecard"
   ],
   "enabled": true,
@@ -19,7 +17,6 @@
   "reviewers": ["marcschaeferger"],
   "prConcurrentLimit": 20,
   "prHourlyLimit": 6,
-  "pinDigests": true,
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "schedule": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     name: Lint & Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: read
@@ -156,7 +156,7 @@ jobs:
 
   test:
     name: Test & Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: lint
     permissions:
       contents: read
@@ -287,7 +287,7 @@ jobs:
 
   security:
     name: Security Scans
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: test
     permissions:
       actions: read

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/continuous-security.yml
+++ b/.github/workflows/continuous-security.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   scheduled-scans:
     name: Weekly Deep Scans
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/deepsource-coverage.yml
+++ b/.github/workflows/deepsource-coverage.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   coverage:
     name: Run tests and report coverage to DeepSource
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Expose DSN via env for conditional checks without referencing `secrets` in expressions
       DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}

--- a/.github/workflows/deprecation-check.yml
+++ b/.github/workflows/deprecation-check.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   scan-deprecations:
     name: Scan for deprecated API usage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Sync labels from .github/labels.json
         env:

--- a/.github/workflows/renovate-validate.yml
+++ b/.github/workflows/renovate-validate.yml
@@ -13,7 +13,7 @@ jobs:
   validate:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate Renovate Config (dry-run)


### PR DESCRIPTION
Update GitHub Actions workflows to use Ubuntu 24.04 as the runner environment, ensuring compatibility with the latest features and security updates. Additionally, refine Renovate's dependency pinning rules.

