### PR TITLE
fix: preserve TCP and UDP config during sanitization

### DIFF
--- a/internal/transform/sanitize/sanitize.go
+++ b/internal/transform/sanitize/sanitize.go
@@ -125,6 +125,8 @@ func SanitizeTraefikConfig(cfg *traefikconfig.Config) (*traefikconfig.Config, er
 			Services:          make(map[string]json.RawMessage, len(cfg.HTTP.Services)),
 			ServersTransports: make(map[string]json.RawMessage, len(cfg.HTTP.ServersTransports)),
 		},
+		TCP: cfg.TCP,
+		UDP: cfg.UDP,
 	}
 	mappings := &nameMappings{
 		middlewares: make(map[string]string, len(cfg.HTTP.Middlewares)),

--- a/internal/transform/sanitize/sanitize_test.go
+++ b/internal/transform/sanitize/sanitize_test.go
@@ -79,6 +79,22 @@ func TestSanitizeTraefikConfig(t *testing.T) {
 	require.Contains(t, rawMws, sanitizedRedirectMw)
 }
 
+func TestSanitizeTraefikConfigPreservesTCPAndUDP(t *testing.T) {
+	tcp := &traefikconfig.TCPUDPConfig{
+		Routers:  map[string]json.RawMessage{"tcp-router": json.RawMessage(`{}`)},
+		Services: map[string]json.RawMessage{"tcp-service": json.RawMessage(`{}`)},
+	}
+	udp := &traefikconfig.TCPUDPConfig{
+		Routers:  map[string]json.RawMessage{"udp-router": json.RawMessage(`{}`)},
+		Services: map[string]json.RawMessage{"udp-service": json.RawMessage(`{}`)},
+	}
+
+	sanitized, err := SanitizeTraefikConfig(&traefikconfig.Config{TCP: tcp, UDP: udp})
+	require.NoError(t, err)
+	require.Same(t, tcp, sanitized.TCP)
+	require.Same(t, udp, sanitized.UDP)
+}
+
 func TestSanitizeTraefikConfigRewritesNestedReferences(t *testing.T) {
 	cfg := &traefikconfig.Config{
 		HTTP: traefikconfig.HTTPConfig{


### PR DESCRIPTION
## Summary
- preserve TCP and UDP dynamic config while sanitizing HTTP resources
- add a regression test covering both protocol sections

## Testing
- `go test ./internal/transform/sanitize`
- `go test ./...`
- `go vet ./...`