### PR TITLE
fix: reconcile external HTTP targets

### DIFF
--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -286,11 +286,26 @@ func deleteImmediate(ctx context.Context, resIfc resources.ResourceClient, name 
 }
 
 func (c *Controller) reconcileServices(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, services map[string]json.RawMessage) error {
-	processed := protocol.ProcessServices(c.cfg, services)
+	processed, kubeServices, endpointSlices, err := protocol.ProcessHTTPServices(c.cfg, services, c.cfg.Namespace)
+	if err != nil {
+		return err
+	}
+	if err := c.applyProtocolServices(ctx, kubeServices); err != nil {
+		return err
+	}
+	if err := c.applyProtocolSlices(ctx, endpointSlices); err != nil {
+		return err
+	}
 	if err := c.applyDesiredObjects(ctx, dyn, gvr, processed); err != nil {
 		return err
 	}
-	return c.gcStaleObjects(ctx, dyn, gvr, processed, "TraefikService")
+	if err := c.gcStaleObjects(ctx, dyn, gvr, processed, "TraefikService"); err != nil {
+		return err
+	}
+	if err := c.gcStaleCoreServices(ctx, desiredServiceNames(kubeServices), "http"); err != nil {
+		return err
+	}
+	return c.gcStaleEndpointSlices(ctx, desiredEndpointSliceNames(endpointSlices), "http")
 }
 
 func (c *Controller) reconcileServersTransports(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, transports map[string]json.RawMessage) error {
@@ -339,10 +354,10 @@ func (c *Controller) reconcileTCP(ctx context.Context, cfg *traefikconfig.Config
 	if err := c.gcStaleObjects(ctx, c.dyn, c.gvrIngressRouteTCP, desiredRoutes, "IngressRouteTCP"); err != nil {
 		return err
 	}
-	if err := c.gcStaleCoreServices(ctx, desiredSvc); err != nil {
+	if err := c.gcStaleCoreServices(ctx, desiredSvc, "tcp"); err != nil {
 		return err
 	}
-	if err := c.gcStaleEndpointSlices(ctx, desiredSlices); err != nil {
+	if err := c.gcStaleEndpointSlices(ctx, desiredSlices, "tcp"); err != nil {
 		return err
 	}
 	return nil
@@ -381,10 +396,10 @@ func (c *Controller) reconcileUDP(ctx context.Context, cfg *traefikconfig.Config
 	if err := c.gcStaleObjects(ctx, c.dyn, c.gvrIngressRouteUDP, desiredRoutes, "IngressRouteUDP"); err != nil {
 		return err
 	}
-	if err := c.gcStaleCoreServices(ctx, desiredSvc); err != nil {
+	if err := c.gcStaleCoreServices(ctx, desiredSvc, "udp"); err != nil {
 		return err
 	}
-	if err := c.gcStaleEndpointSlices(ctx, desiredSlices); err != nil {
+	if err := c.gcStaleEndpointSlices(ctx, desiredSlices, "udp"); err != nil {
 		return err
 	}
 	return nil
@@ -523,9 +538,26 @@ func (c *Controller) ensureManagedEndpointSliceMeta(es *discoveryv1.EndpointSlic
 	es.Annotations[c.cfg.ManagedAnnoKey] = c.cfg.ManagedAnnoValue
 }
 
-func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string]json.RawMessage) error {
+func desiredServiceNames(services []*corev1.Service) map[string]json.RawMessage {
+	desired := make(map[string]json.RawMessage, len(services))
+	for _, service := range services {
+		desired[service.Name] = json.RawMessage("{}")
+	}
+	return desired
+}
+
+func desiredEndpointSliceNames(endpointSlices []*discoveryv1.EndpointSlice) map[string]json.RawMessage {
+	desired := make(map[string]json.RawMessage, len(endpointSlices))
+	for _, endpointSlice := range endpointSlices {
+		desired[endpointSlice.Name] = json.RawMessage("{}")
+	}
+	return desired
+}
+
+func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string]json.RawMessage, protocolName string) error {
 	cli := c.kube.CoreV1().Services(c.cfg.Namespace)
-	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue)})
+	selector := fmt.Sprintf("%s=%s,%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue, protocol.ArtifactProtocolLabel, protocolName)
+	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return err
 	}
@@ -542,9 +574,10 @@ func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string
 	return nil
 }
 
-func (c *Controller) gcStaleEndpointSlices(ctx context.Context, desired map[string]json.RawMessage) error {
+func (c *Controller) gcStaleEndpointSlices(ctx context.Context, desired map[string]json.RawMessage, protocolName string) error {
 	cli := c.kube.DiscoveryV1().EndpointSlices(c.cfg.Namespace)
-	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue)})
+	selector := fmt.Sprintf("%s=%s,%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue, protocol.ArtifactProtocolLabel, protocolName)
+	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return err
 	}

--- a/internal/transform/protocol/http_conversion.go
+++ b/internal/transform/protocol/http_conversion.go
@@ -8,9 +8,15 @@ import (
 	"strings"
 
 	logrus "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"pangolin-kube-controller/internal/config"
+	"pangolin-kube-controller/internal/transform/sanitize"
 )
+
+// ArtifactProtocolLabel scopes generated Kubernetes resources by protocol.
+const ArtifactProtocolLabel = "pangolin-kube-controller/protocol"
 
 type kubeServiceTarget struct {
 	name      string
@@ -21,39 +27,88 @@ type kubeServiceTarget struct {
 
 // ProcessServices rewrites TraefikService specs for load balancer conversions and logging.
 func ProcessServices(cfg *config.Config, services map[string]json.RawMessage) map[string]json.RawMessage {
-	if services == nil {
-		return nil
-	}
-	out := make(map[string]json.RawMessage, len(services))
-	for name, raw := range services {
-		out[name] = processSingleService(cfg, name, raw)
-	}
-	return out
+	processed, _, _, _ := ProcessHTTPServices(cfg, services, "")
+	return processed
 }
 
 func processSingleService(cfg *config.Config, name string, raw json.RawMessage) json.RawMessage {
+	processed, _, _, _ := processSingleHTTPService(cfg, "", name, raw)
+	return processed
+}
+
+// ProcessHTTPServices rewrites HTTP service specs and builds Kubernetes
+// artifacts for load balancers whose servers are not Kubernetes Services.
+func ProcessHTTPServices(cfg *config.Config, services map[string]json.RawMessage, namespace string) (map[string]json.RawMessage, []*corev1.Service, []*discoveryv1.EndpointSlice, error) {
+	if services == nil {
+		return nil, nil, nil, nil
+	}
+	out := make(map[string]json.RawMessage, len(services))
+	var kubeServices []*corev1.Service
+	var endpointSlices []*discoveryv1.EndpointSlice
+	for name, raw := range services {
+		processed, svc, endpointSlice, err := processSingleHTTPService(cfg, namespace, name, raw)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("process HTTP service %s: %w", name, err)
+		}
+		out[name] = processed
+		if svc != nil {
+			kubeServices = append(kubeServices, svc)
+			endpointSlices = append(endpointSlices, endpointSlice)
+		}
+	}
+	return out, kubeServices, endpointSlices, nil
+}
+
+func processSingleHTTPService(cfg *config.Config, namespace, name string, raw json.RawMessage) (json.RawMessage, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	trim := strings.TrimSpace(string(raw))
 	if trim != "" && trim != "{}" {
-		return processNonEmptyService(name, raw)
+		return processNonEmptyHTTPService(namespace, name, raw)
 	}
-	return processEmptyService(cfg, name, raw)
+	return processEmptyService(cfg, name, raw), nil, nil, nil
 }
 
 func processNonEmptyService(name string, raw json.RawMessage) json.RawMessage {
+	processed, _, _, _ := processNonEmptyHTTPService("", name, raw)
+	return processed
+}
+
+func processNonEmptyHTTPService(namespace, name string, raw json.RawMessage) (json.RawMessage, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	var spec map[string]interface{}
-	if err := json.Unmarshal(raw, &spec); err == nil {
-		if target, ok := convertLoadBalancerToK8sService(spec); ok {
-			if b, err := json.Marshal(spec); err == nil {
-				raw = b
-				logrus.Infof("TraefikService %s converted to Kubernetes Service %s/%s port=%d scheme=%s", name, target.namespace, target.name, target.port, target.scheme)
-			} else {
-				logrus.Warnf("TraefikService %s conversion marshal failed: %v", name, err)
-			}
-		} else if urls := extractServiceURLs(spec); len(urls) > 0 {
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return raw, nil, nil, nil
+	}
+	if target, ok := convertLoadBalancerToK8sService(spec); ok {
+		converted, err := json.Marshal(spec)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("marshal Kubernetes Service reference: %w", err)
+		}
+		logrus.Infof("TraefikService %s converted to Kubernetes Service %s/%s port=%d scheme=%s", name, target.namespace, target.name, target.port, target.scheme)
+		return converted, nil, nil, nil
+	}
+	target, ok := parseExternalServiceTargets(spec)
+	if !ok || namespace == "" {
+		if urls := extractServiceURLs(spec); len(urls) > 0 {
 			logrus.Infof("TraefikService %s servers=%v", name, urls)
 		}
+		return raw, nil, nil, nil
 	}
-	return raw
+	kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", name, target.port))
+	rewriteAsKubeService(spec, kubeName, namespace, target.port, target.scheme, target.serviceOptions)
+	converted, err := json.Marshal(spec)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal external Service reference: %w", err)
+	}
+	svc := buildHeadlessService(namespace, kubeName, int32(target.port), corev1.ProtocolTCP)
+	svc.Labels = map[string]string{ArtifactProtocolLabel: "http"}
+	endpointSlice, err := buildEndpointSlice(namespace, kubeName, int32(target.port), target.hosts, corev1.ProtocolTCP)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	endpointSlice.Labels = map[string]string{
+		ArtifactProtocolLabel:        "http",
+		discoveryv1.LabelServiceName: kubeName,
+	}
+	return converted, svc, endpointSlice, nil
 }
 
 func processEmptyService(cfg *config.Config, name string, raw json.RawMessage) json.RawMessage {
@@ -118,18 +173,88 @@ func convertLoadBalancerToK8sService(spec map[string]interface{}) (*kubeServiceT
 	if !ok || target == nil {
 		return nil, false
 	}
-	serviceEntry := map[string]interface{}{
-		"name":      target.name,
-		"namespace": target.namespace,
-		"kind":      "Service",
-		"port":      target.port,
+	rewriteAsKubeService(spec, target.name, target.namespace, target.port, target.scheme, nil)
+	return target, true
+}
+
+type externalServiceTarget struct {
+	hosts          []string
+	port           int
+	scheme         string
+	serviceOptions map[string]interface{}
+}
+
+func parseExternalServiceTargets(spec map[string]interface{}) (*externalServiceTarget, bool) {
+	lb, ok := spec["loadBalancer"].(map[string]interface{})
+	if !ok {
+		return nil, false
 	}
-	if target.scheme == "https" {
+	servers, ok := lb["servers"].([]interface{})
+	if !ok {
+		return nil, false
+	}
+	serviceOptions := make(map[string]interface{}, len(lb)-1)
+	for key, value := range lb {
+		if key != "servers" {
+			serviceOptions[key] = value
+		}
+	}
+	var target *externalServiceTarget
+	for _, server := range servers {
+		serverMap, ok := server.(map[string]interface{})
+		if !ok || len(serverMap) != 1 {
+			return nil, false
+		}
+		rawURL, ok := serverMap["url"].(string)
+		if !ok {
+			return nil, false
+		}
+		parsed, err := netURLParse(rawURL)
+		if err != nil || validateExternalServiceURL(parsed, rawURL) != nil {
+			return nil, false
+		}
+		port := derivePort(parsed)
+		if target == nil {
+			target = &externalServiceTarget{port: port, scheme: parsed.Scheme, serviceOptions: serviceOptions}
+		} else if target.port != port || target.scheme != parsed.Scheme {
+			return nil, false
+		}
+		target.hosts = append(target.hosts, parsed.Hostname())
+	}
+	return target, target != nil
+}
+
+func validateExternalServiceURL(parsed *url.URL, raw string) error {
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported scheme %s", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("missing host")
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" {
+		return fmt.Errorf("unsupported path or query components in %s", raw)
+	}
+	if strings.Contains(parsed.Hostname(), ".svc.") || strings.HasSuffix(parsed.Hostname(), ".svc") {
+		return fmt.Errorf("target is a Kubernetes Service")
+	}
+	return nil
+}
+
+func rewriteAsKubeService(spec map[string]interface{}, name, namespace string, port int, scheme string, options map[string]interface{}) {
+	serviceEntry := map[string]interface{}{
+		"name":      name,
+		"namespace": namespace,
+		"kind":      "Service",
+		"port":      port,
+	}
+	if scheme == "https" {
 		serviceEntry["scheme"] = "https"
+	}
+	for key, value := range options {
+		serviceEntry[key] = value
 	}
 	spec["weighted"] = map[string]interface{}{"services": []interface{}{serviceEntry}}
 	delete(spec, "loadBalancer")
-	return target, true
 }
 
 // extractLBServers validates top-level loadBalancer shape & returns servers list.

--- a/internal/transform/protocol/process_services_test.go
+++ b/internal/transform/protocol/process_services_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"pangolin-kube-controller/internal/config"
 )
@@ -190,6 +191,50 @@ func TestProcessServicesKubeServiceConversion(t *testing.T) {
 	// After conversion, loadBalancer should be replaced by weighted.
 	require.Contains(t, spec, "weighted")
 	require.NotContains(t, spec, "loadBalancer")
+}
+
+func TestProcessHTTPServicesExternalTunnelTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName = "svc"
+		port        = 8443
+		kubeName    = "svc-8443"
+	)
+	services := map[string]json.RawMessage{
+		serviceName: json.RawMessage(`{"loadBalancer":{"servers":[{"url":"https://192.0.2.1:8443"}],"serversTransport":"transport","sticky":{"cookie":{"name":"sticky"}}}}`),
+	}
+
+	processed, kubeServices, endpointSlices, err := ProcessHTTPServices(&config.Config{}, services, "traefik")
+	require.NoError(t, err)
+	require.Len(t, kubeServices, 1)
+	require.Len(t, endpointSlices, 1)
+
+	service := kubeServices[0]
+	require.Equal(t, kubeName, service.Name)
+	require.Equal(t, "traefik", service.Namespace)
+	require.Equal(t, "None", service.Spec.ClusterIP)
+	require.EqualValues(t, port, service.Spec.Ports[0].Port)
+	require.Equal(t, "http", service.Labels[ArtifactProtocolLabel])
+
+	endpointSlice := endpointSlices[0]
+	require.Equal(t, discoveryv1.AddressTypeIPv4, endpointSlice.AddressType)
+	require.Equal(t, []string{"192.0.2.1"}, endpointSlice.Endpoints[0].Addresses)
+	require.Equal(t, kubeName, endpointSlice.Labels[discoveryv1.LabelServiceName])
+
+	var spec map[string]interface{}
+	require.NoError(t, json.Unmarshal(processed[serviceName], &spec))
+	require.NotContains(t, spec, "loadBalancer")
+	weighted := spec["weighted"].(map[string]interface{})
+	entries := weighted["services"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+	require.Equal(t, kubeName, entry["name"])
+	require.Equal(t, "traefik", entry["namespace"])
+	require.Equal(t, "Service", entry["kind"])
+	require.Equal(t, "https", entry["scheme"])
+	require.Equal(t, "transport", entry["serversTransport"])
+	require.Contains(t, entry, "sticky")
+	require.EqualValues(t, port, entry["port"])
 }
 
 func TestProcessServicesPreservesNonConvertible(t *testing.T) {

--- a/internal/transform/protocol/tcp_udp.go
+++ b/internal/transform/protocol/tcp_udp.go
@@ -76,11 +76,14 @@ func buildTCPKubeArtifacts(namespace string, keys []string, info map[string]tcpS
 		meta := info[dyn]
 		kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", dyn, meta.port))
 		nameMap[dyn] = kubeName
-		svcs = append(svcs, buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolTCP))
+		svc := buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolTCP)
+		svc.Labels = map[string]string{ArtifactProtocolLabel: "tcp"}
+		svcs = append(svcs, svc)
 		eps, e := buildEndpointSlice(namespace, kubeName, meta.port, meta.hosts, corev1.ProtocolTCP)
 		if e != nil {
 			return nil, nil, nil, e
 		}
+		eps.Labels = map[string]string{ArtifactProtocolLabel: "tcp", discoveryv1.LabelServiceName: kubeName}
 		slices = append(slices, eps)
 	}
 	return nameMap, svcs, slices, nil
@@ -219,11 +222,14 @@ func buildUDPKubeArtifacts(namespace string, keys []string, info map[string]udpS
 		meta := info[dyn]
 		kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", dyn, meta.port))
 		nameMap[dyn] = kubeName
-		svcs = append(svcs, buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolUDP))
+		svc := buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolUDP)
+		svc.Labels = map[string]string{ArtifactProtocolLabel: "udp"}
+		svcs = append(svcs, svc)
 		eps, e := buildEndpointSlice(namespace, kubeName, meta.port, meta.hosts, corev1.ProtocolUDP)
 		if e != nil {
 			return nil, nil, nil, e
 		}
+		eps.Labels = map[string]string{ArtifactProtocolLabel: "udp", discoveryv1.LabelServiceName: kubeName}
 		slices = append(slices, eps)
 	}
 	return nameMap, svcs, slices, nil


### PR DESCRIPTION
## Summary
- convert external HTTP tunnel targets into selectorless Kubernetes Services and EndpointSlices
- preserve HTTPS, servers transport, and sticky-session settings on generated Service references
- scope generated HTTP, TCP, and UDP artifacts so protocol reconciliation does not garbage-collect another protocol
- add regression coverage using generic documentation-only target data

## Testing
- `go test ./internal/transform/protocol ./internal/controller`
- `go test ./...`
- `go vet ./...`