### PR TITLE
fix: stabilize Traefik reconciliation and instance identity

### DIFF
--- a/internal/apply/apply_extra_test.go
+++ b/internal/apply/apply_extra_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	traefikconfig "pangolin-kube-controller/internal/transform/config"
 )
@@ -25,6 +29,22 @@ func newTestUnstructuredOps(t *testing.T) (*UnstructuredOps, *fake.FakeDynamicCl
 		testGVR: "MiddlewareList",
 	}
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	dyn.PrependReactor("patch", testGVR.Resource, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction := action.(k8stesting.PatchAction)
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(patchAction.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		obj.SetNamespace(action.GetNamespace())
+		_, err := dyn.Tracker().Get(testGVR, action.GetNamespace(), obj.GetName())
+		switch {
+		case k8serrors.IsNotFound(err):
+			err = dyn.Tracker().Create(testGVR, obj, action.GetNamespace())
+		case err == nil:
+			err = dyn.Tracker().Update(testGVR, obj, action.GetNamespace())
+		}
+		return true, obj, err
+	})
 	ops := &UnstructuredOps{
 		Dyn:       dyn,
 		GVR:       testGVR,
@@ -44,7 +64,7 @@ func testMetadataConfig() MetadataConfig {
 	}
 }
 
-// TestApplyCreatesNewResource verifies that Apply creates the resource when it
+// TestApplyCreatesNewResource verifies that SSA creates the resource when it
 // does not yet exist in the fake client.
 func TestApplyCreatesNewResource(t *testing.T) {
 	t.Parallel()
@@ -78,23 +98,24 @@ func TestApplyInvalidJSON(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestApplyUpdateExistingResource calls Apply twice on the same name: the
-// second call should trigger the patch (update) path. Since the fake dynamic
-// client does not support SSA ApplyPatchType, the second call is expected to
-// return an error (verifying the update path is reached without a panic).
+// TestApplyUpdateExistingResource calls Apply twice on the same name and
+// verifies that the changed spec is reconciled through the same SSA path.
 func TestApplyUpdateExistingResourceTriesPatch(t *testing.T) {
 	t.Parallel()
 
-	ops, _ := newTestUnstructuredOps(t)
+	ops, dyn := newTestUnstructuredOps(t)
 	raw := json.RawMessage(`{"passHostHeader": true}`)
 
-	// First apply – creates the resource.
+	// First apply creates the resource through SSA.
 	require.NoError(t, ops.Apply(context.Background(), "reused-mw", raw, testMetadataConfig()))
 
-	// Second apply with changed spec – reaches the patch path.
-	// The fake client doesn't support SSA, so it may return an error.
-	// What matters is that Apply is called without panicking.
+	// Second apply with changed spec uses SSA again.
 	raw2 := json.RawMessage(`{"passHostHeader": false}`)
-	_ = ops.Apply(context.Background(), "reused-mw", raw2, testMetadataConfig())
-	// No assertion on the error – we just confirm no panic occurs.
+	require.NoError(t, ops.Apply(context.Background(), "reused-mw", raw2, testMetadataConfig()))
+	got, err := dyn.Resource(testGVR).Namespace(TestNS).Get(context.Background(), "reused-mw", metav1.GetOptions{})
+	require.NoError(t, err)
+	value, found, err := unstructured.NestedBool(got.Object, "spec", "passHostHeader")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.False(t, value)
 }

--- a/internal/apply/ingressroute.go
+++ b/internal/apply/ingressroute.go
@@ -17,46 +17,45 @@ import (
 const FieldManagerName = "pangolin-kube-controller"
 
 type IngressRouteOps struct {
-	ResIfc            resources.ResourceClient
-	Namespace         string
-	ManagedLabelKey   string
-	ManagedLabelValue string
-	ManagedAnnoKey    string
-	ManagedAnnoValue  string
-	IngressClass      string
-	ReadOnly          bool
+	ResIfc                    resources.ResourceClient
+	Namespace                 string
+	ManagedLabelKey           string
+	ManagedLabelValue         string
+	TraefikInstanceLabelKey   string
+	TraefikInstanceLabelValue string
+	ManagedAnnoKey            string
+	ManagedAnnoValue          string
+	IngressClass              string
+	ReadOnly                  bool
 }
 
 func (o *IngressRouteOps) Apply(ctx context.Context, name string, u map[string]interface{}) error {
 	if o.ReadOnly {
 		return nil
 	}
+	metaCfg := MetadataConfig{
+		ManagedLabelKey:           o.ManagedLabelKey,
+		ManagedLabelValue:         o.ManagedLabelValue,
+		TraefikInstanceLabelKey:   o.TraefikInstanceLabelKey,
+		TraefikInstanceLabelValue: o.TraefikInstanceLabelValue,
+		ManagedAnnoKey:            o.ManagedAnnoKey,
+		ManagedAnnoValue:          o.ManagedAnnoValue,
+		IngressClass:              o.IngressClass,
+	}
 	existing, err := o.ResIfc.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			meta, _ := BuildMetadataForApply(nil, name, o.Namespace, "IngressRoute", MetadataConfig{
-				ManagedLabelKey:   o.ManagedLabelKey,
-				ManagedLabelValue: o.ManagedLabelValue,
-				ManagedAnnoKey:    o.ManagedAnnoKey,
-				ManagedAnnoValue:  o.ManagedAnnoValue,
-				IngressClass:      o.IngressClass,
-			})
+			meta, _ := BuildMetadataForApply(nil, name, o.Namespace, "IngressRoute", metaCfg)
 			routing.AnnotateRouterEntryPointsIfPresent(u, meta)
 			u["metadata"] = meta
 			return CreateUnstructured(ctx, o.ResIfc, u, "IngressRoute")
 		}
 		return err
 	}
-	meta, force := BuildMetadataForApply(existing, name, o.Namespace, "IngressRoute", MetadataConfig{
-		ManagedLabelKey:   o.ManagedLabelKey,
-		ManagedLabelValue: o.ManagedLabelValue,
-		ManagedAnnoKey:    o.ManagedAnnoKey,
-		ManagedAnnoValue:  o.ManagedAnnoValue,
-		IngressClass:      o.IngressClass,
-	})
+	meta, force := BuildMetadataForApply(existing, name, o.Namespace, "IngressRoute", metaCfg)
 	routing.AnnotateRouterEntryPointsIfPresent(u, meta)
 	u["metadata"] = meta
-	return PatchUnstructured(ctx, o.ResIfc, name, u, existing, "IngressRoute", PatchConfig{Force: force, SSAForce: false})
+	return PatchUnstructured(ctx, o.ResIfc, name, u, existing, "IngressRoute", PatchConfig{Force: force, MetadataConfig: metaCfg})
 }
 
 func (o *IngressRouteOps) ApplySingle(ctx context.Context, m map[string]interface{}, kind string) error {
@@ -69,30 +68,27 @@ func (o *IngressRouteOps) ApplySingle(ctx context.Context, m map[string]interfac
 	if o.ReadOnly {
 		return nil
 	}
+	metaCfg := MetadataConfig{
+		ManagedLabelKey:           o.ManagedLabelKey,
+		ManagedLabelValue:         o.ManagedLabelValue,
+		TraefikInstanceLabelKey:   o.TraefikInstanceLabelKey,
+		TraefikInstanceLabelValue: o.TraefikInstanceLabelValue,
+		ManagedAnnoKey:            o.ManagedAnnoKey,
+		ManagedAnnoValue:          o.ManagedAnnoValue,
+		IngressClass:              o.IngressClass,
+	}
 	existing, err := o.ResIfc.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			meta, _ := BuildMetadataForApply(nil, name, o.Namespace, kind, MetadataConfig{
-				ManagedLabelKey:   o.ManagedLabelKey,
-				ManagedLabelValue: o.ManagedLabelValue,
-				ManagedAnnoKey:    o.ManagedAnnoKey,
-				ManagedAnnoValue:  o.ManagedAnnoValue,
-				IngressClass:      o.IngressClass,
-			})
+			meta, _ := BuildMetadataForApply(nil, name, o.Namespace, kind, metaCfg)
 			m["metadata"] = meta
 			return CreateUnstructured(ctx, o.ResIfc, m, kind)
 		}
 		return err
 	}
-	meta, force := BuildMetadataForApply(existing, name, o.Namespace, kind, MetadataConfig{
-		ManagedLabelKey:   o.ManagedLabelKey,
-		ManagedLabelValue: o.ManagedLabelValue,
-		ManagedAnnoKey:    o.ManagedAnnoKey,
-		ManagedAnnoValue:  o.ManagedAnnoValue,
-		IngressClass:      o.IngressClass,
-	})
+	meta, force := BuildMetadataForApply(existing, name, o.Namespace, kind, metaCfg)
 	m["metadata"] = meta
-	return PatchUnstructured(ctx, o.ResIfc, name, m, existing, kind, PatchConfig{Force: force, SSAForce: false})
+	return PatchUnstructured(ctx, o.ResIfc, name, m, existing, kind, PatchConfig{Force: force, MetadataConfig: metaCfg})
 }
 
 func logApplySingleMalformedInput(kind string, input map[string]interface{}, metaIn map[string]interface{}) {

--- a/internal/apply/ingressroute_test.go
+++ b/internal/apply/ingressroute_test.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -15,6 +16,90 @@ import (
 
 	"pangolin-kube-controller/internal/kube/resources"
 )
+
+func TestIngressRouteOpsPropagatesTraefikIdentity(t *testing.T) {
+	t.Parallel()
+
+	const unrelatedLabel = "example.com/owner"
+	client := &fakeResourceClient{}
+	ops := &IngressRouteOps{
+		ResIfc:                    client,
+		Namespace:                 TestNS,
+		ManagedLabelKey:           ManagedBy,
+		ManagedLabelValue:         Controller,
+		TraefikInstanceLabelKey:   InstanceLabelKeyFull,
+		TraefikInstanceLabelValue: InstanceLabelValueMyInstance,
+		ManagedAnnoKey:            AnnoKey,
+		ManagedAnnoValue:          AnnoVal,
+		IngressClass:              TraefikIngressClass,
+	}
+
+	desired := map[string]interface{}{
+		"apiVersion": "traefik.io/v1alpha1",
+		"kind":       "IngressRoute",
+		"metadata":   map[string]interface{}{"name": TestRoute},
+		"spec":       map[string]interface{}{},
+	}
+	require.NoError(t, ops.Apply(context.Background(), TestRoute, desired))
+	labels := patchLabels(t, client.patchBytes)
+	require.Equal(t, InstanceLabelValueMyInstance, labels[InstanceLabelKeyFull])
+	require.Equal(t, FieldManager, client.patchOptions.FieldManager)
+
+	client.existing = &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name": TestRoute, "namespace": TestNS,
+			"labels":      map[string]interface{}{ManagedBy: Controller, unrelatedLabel: "platform"},
+			"annotations": map[string]interface{}{AnnoKey: AnnoVal},
+		},
+	}}
+	require.NoError(t, ops.Apply(context.Background(), TestRoute, desired))
+	labels = patchLabels(t, client.patchBytes)
+	require.Equal(t, InstanceLabelValueMyInstance, labels[InstanceLabelKeyFull])
+	require.NotContains(t, labels, unrelatedLabel)
+	require.NotNil(t, client.patchOptions.Force, "repairing missing managed identity must adopt SSA ownership")
+	require.True(t, *client.patchOptions.Force)
+
+	client.existing.SetLabels(map[string]string{
+		ManagedBy: Controller, unrelatedLabel: "platform", InstanceLabelKeyFull: InstanceLabelValueMyInstance,
+	})
+	client.existing.SetAnnotations(map[string]string{
+		AnnoKey: AnnoVal, "traefikconfig.ingress.kubernetes.io/router.ingressclass": TraefikIngressClass,
+	})
+	require.NoError(t, ops.Apply(context.Background(), TestRoute, desired))
+	labels = patchLabels(t, client.patchBytes)
+	require.Equal(t, InstanceLabelValueMyInstance, labels[InstanceLabelKeyFull])
+	require.NotContains(t, labels, unrelatedLabel)
+	require.Nil(t, client.patchOptions.Force, "repeated reconcile must not force unchanged ownership")
+}
+
+func TestIngressRouteOpsApplySinglePropagatesTraefikIdentity(t *testing.T) {
+	t.Parallel()
+	client := &fakeResourceClient{}
+	ops := &IngressRouteOps{
+		ResIfc: client, Namespace: TestNS,
+		ManagedLabelKey: ManagedBy, ManagedLabelValue: Controller,
+		TraefikInstanceLabelKey: InstanceLabelKeyFull, TraefikInstanceLabelValue: InstanceLabelValueMyInstance,
+		ManagedAnnoKey: AnnoKey, ManagedAnnoValue: AnnoVal,
+	}
+	require.NoError(t, ops.ApplySingle(context.Background(), map[string]interface{}{
+		"apiVersion": "traefik.io/v1alpha1",
+		"kind":       "IngressRouteTCP",
+		"metadata":   map[string]interface{}{"name": TestMW},
+		"spec":       map[string]interface{}{},
+	}, "IngressRouteTCP"))
+	require.Equal(t, InstanceLabelValueMyInstance, patchLabels(t, client.patchBytes)[InstanceLabelKeyFull])
+}
+
+func patchLabels(t *testing.T, patch []byte) map[string]interface{} {
+	t.Helper()
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(patch, &obj))
+	meta, ok := obj["metadata"].(map[string]interface{})
+	require.True(t, ok)
+	labels, ok := meta["labels"].(map[string]interface{})
+	require.True(t, ok)
+	return labels
+}
 
 func TestIngressRouteOpsApplyReadOnly(t *testing.T) {
 	t.Parallel()
@@ -193,12 +278,14 @@ func TestIngressRouteOpsApplySingleGetError(t *testing.T) {
 
 type fakeResourceClient struct {
 	resources.ResourceClient
-	existing    *unstructured.Unstructured
-	getErr      error
-	createErr   error
-	patchErr    error
-	createCount int
-	patchCount  int
+	existing     *unstructured.Unstructured
+	getErr       error
+	createErr    error
+	patchErr     error
+	createCount  int
+	patchCount   int
+	patchBytes   []byte
+	patchOptions metav1.PatchOptions
 }
 
 func (c *fakeResourceClient) Get(_ context.Context, name string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
@@ -219,8 +306,10 @@ func (c *fakeResourceClient) Create(_ context.Context, obj *unstructured.Unstruc
 	return obj, nil
 }
 
-func (c *fakeResourceClient) Patch(_ context.Context, name string, _ types.PatchType, _ []byte, _ metav1.PatchOptions) (*unstructured.Unstructured, error) {
+func (c *fakeResourceClient) Patch(_ context.Context, name string, _ types.PatchType, patch []byte, options metav1.PatchOptions) (*unstructured.Unstructured, error) {
 	c.patchCount++
+	c.patchBytes = append([]byte(nil), patch...)
+	c.patchOptions = options
 	if c.patchErr != nil {
 		return nil, c.patchErr
 	}

--- a/internal/apply/metadata.go
+++ b/internal/apply/metadata.go
@@ -14,13 +14,16 @@ func GetMetadataMap(existing *unstructured.Unstructured, getter func(*unstructur
 }
 
 func UpdateMetadataField(existing map[string]string, key, desiredValue string, target map[string]interface{}) bool {
+	// Server-Side Apply requires every controller-owned desired field to be
+	// present on every apply. Omitting an unchanged field relinquishes it and
+	// can prune it from the live object. Only unrelated fields remain absent
+	// from this patch, so their ownership and values are preserved.
+	target[key] = desiredValue
 	if existing == nil {
-		target[key] = desiredValue
 		return true
 	}
 	val, ok := existing[key]
 	if !ok || val != desiredValue {
-		target[key] = desiredValue
 		return true
 	}
 	return false

--- a/internal/apply/metadata_test.go
+++ b/internal/apply/metadata_test.go
@@ -76,6 +76,9 @@ func TestUpdateMetadataField(t *testing.T) {
 		if got {
 			t.Error("UpdateMetadataField() = true, want false for unchanged value")
 		}
+		if target["key"] != "value" {
+			t.Errorf("target[key] = %v, want value retained in SSA payload", target["key"])
+		}
 	})
 
 	t.Run("existing value different", func(t *testing.T) {
@@ -147,11 +150,13 @@ func TestBuildMetadataForApplyUpdateSameValuesNoForce(t *testing.T) {
 	if force {
 		t.Error("force = true, want false when existing matches")
 	}
-	if _, hasLabels := meta["labels"]; hasLabels {
-		t.Error("meta should not have labels when unchanged")
+	labels := meta["labels"].(map[string]interface{})
+	if labels[managedLabelKey] != managedLabelValue || labels[instanceLabelKey] != instanceLabelVal {
+		t.Errorf("unchanged controller-owned labels missing from SSA payload: %v", labels)
 	}
-	if _, hasAnnotations := meta["annotations"]; hasAnnotations {
-		t.Error("meta should not have annotations when unchanged")
+	annotations := meta["annotations"].(map[string]interface{})
+	if annotations[managedAnnoKey] != managedAnnoValue {
+		t.Errorf("unchanged controller-owned annotation missing from SSA payload: %v", annotations)
 	}
 }
 
@@ -172,6 +177,36 @@ func TestBuildMetadataForApplyUpdateDifferentValuesForces(t *testing.T) {
 	labels := meta["labels"].(map[string]interface{})
 	if labels[managedLabelKey] != managedLabelValue {
 		t.Errorf("labels[managed] = %v, want %s", labels[managedLabelKey], managedLabelValue)
+	}
+}
+
+func TestBuildMetadataForApplyPreservesUnrelatedExistingLabels(t *testing.T) {
+	cfg := defaultMetadataConfig()
+	existing := &unstructured.Unstructured{}
+	existing.SetLabels(map[string]string{
+		"user.example.com/owner": "platform",
+		managedLabelKey:          managedLabelValue,
+	})
+
+	meta, _ := BuildMetadataForApply(existing, resourceName, testNamespace, "Middleware", cfg)
+	labels := meta["labels"].(map[string]interface{})
+	if _, overwritten := labels["user.example.com/owner"]; overwritten {
+		t.Fatal("unrelated existing label was included in the controller patch")
+	}
+	if labels[instanceLabelKey] != instanceLabelVal {
+		t.Fatalf("instance label = %v, want %s", labels[instanceLabelKey], instanceLabelVal)
+	}
+}
+
+func TestBuildMetadataForApplyWithoutConfiguredIdentity(t *testing.T) {
+	cfg := defaultMetadataConfig()
+	cfg.TraefikInstanceLabelKey = ""
+	cfg.TraefikInstanceLabelValue = ""
+
+	meta, _ := BuildMetadataForApply(nil, resourceName, testNamespace, "Middleware", cfg)
+	labels := meta["labels"].(map[string]interface{})
+	if _, invented := labels[instanceLabelKey]; invented {
+		t.Fatalf("unexpected invented instance label: %v", labels)
 	}
 }
 

--- a/internal/apply/unstructured.go
+++ b/internal/apply/unstructured.go
@@ -56,8 +56,9 @@ type UnstructuredOps struct {
 }
 
 type PatchConfig struct {
-	Force    bool
-	SSAForce bool
+	Force          bool
+	SSAForce       bool
+	MetadataConfig MetadataConfig
 }
 
 type SSAOptions struct {
@@ -94,28 +95,23 @@ func (o *UnstructuredOps) Apply(ctx context.Context, name string, raw json.RawMe
 	var force bool
 	meta, force = BuildMetadataForApply(existing, name, o.Namespace, kind, metaCfg)
 	u["metadata"] = meta
-	return PatchUnstructured(ctx, resIfc, name, u, existing, kind, PatchConfig{Force: force, SSAForce: o.SSAForce})
+	return PatchUnstructured(ctx, resIfc, name, u, existing, kind, PatchConfig{
+		Force:          force,
+		SSAForce:       o.SSAForce,
+		MetadataConfig: metaCfg,
+	})
 }
 
 func CreateUnstructured(ctx context.Context, resIfc resources.ResourceClient, u map[string]interface{}, kind string) error {
-	bytes, err := json.Marshal(u)
+	patchBytes, err := json.Marshal(u)
 	if err != nil {
 		return err
 	}
 	obj := &unstructured.Unstructured{}
-	if err := obj.UnmarshalJSON(bytes); err != nil {
+	if err := obj.UnmarshalJSON(patchBytes); err != nil {
 		return err
 	}
-	createOpts := metav1.CreateOptions{}
-	if IgnoreFieldValidation(kind) {
-		createOpts.FieldValidation = metav1.FieldValidationIgnore
-	}
-	_, err = resIfc.Create(ctx, obj, createOpts)
-	if err != nil {
-		return err
-	}
-	logrus.Infof("Created %s %s", kind, obj.GetName())
-	return nil
+	return ApplySSAWithRetry(ctx, resIfc, obj.GetName(), patchBytes, kind, SSAOptions{})
 }
 
 func PatchUnstructured(ctx context.Context, resIfc resources.ResourceClient, name string, u map[string]interface{}, existing *unstructured.Unstructured, kind string, cfg PatchConfig) error {
@@ -125,11 +121,56 @@ func PatchUnstructured(ctx context.Context, resIfc resources.ResourceClient, nam
 		}
 	}
 	forceOverride := ForceNeededForMetadata(existing, u)
+	legacyAdoption := ShouldAdoptLegacySpec(existing, cfg.MetadataConfig)
 	patchBytes, err := json.Marshal(u)
 	if err != nil {
 		return err
 	}
-	return ApplySSAWithRetry(ctx, resIfc, name, patchBytes, kind, SSAOptions{Force: cfg.Force, ForceOverride: forceOverride, SSAForce: cfg.SSAForce})
+	return ApplySSAWithRetry(ctx, resIfc, name, patchBytes, kind, SSAOptions{Force: cfg.Force || legacyAdoption, ForceOverride: forceOverride, SSAForce: cfg.SSAForce})
+}
+
+func ShouldAdoptLegacySpec(existing *unstructured.Unstructured, cfg MetadataConfig) bool {
+	if existing == nil || !isControllerManaged(existing, cfg) {
+		return false
+	}
+
+	legacyOwnsSpec := false
+	for _, entry := range existing.GetManagedFields() {
+		if !managedFieldsEntryOwnsSpec(entry) {
+			continue
+		}
+		switch entry.Manager {
+		case FieldManager:
+			continue
+		case "controller":
+			if entry.Operation != metav1.ManagedFieldsOperationUpdate {
+				return false
+			}
+			legacyOwnsSpec = true
+		default:
+			return false
+		}
+	}
+	return legacyOwnsSpec
+}
+
+func isControllerManaged(existing *unstructured.Unstructured, cfg MetadataConfig) bool {
+	labels := existing.GetLabels()
+	annotations := existing.GetAnnotations()
+	return (cfg.ManagedLabelKey != "" && labels[cfg.ManagedLabelKey] == cfg.ManagedLabelValue) ||
+		(cfg.ManagedAnnoKey != "" && annotations[cfg.ManagedAnnoKey] == cfg.ManagedAnnoValue)
+}
+
+func managedFieldsEntryOwnsSpec(entry metav1.ManagedFieldsEntry) bool {
+	if entry.FieldsV1 == nil || len(entry.FieldsV1.Raw) == 0 {
+		return false
+	}
+	fields := map[string]interface{}{}
+	if err := json.Unmarshal(entry.FieldsV1.Raw, &fields); err != nil {
+		return false
+	}
+	_, ownsSpec := fields["f:spec"]
+	return ownsSpec
 }
 
 func DiffSpecKeys(existing *unstructured.Unstructured, desired map[string]interface{}) []string {

--- a/internal/apply/unstructured_test.go
+++ b/internal/apply/unstructured_test.go
@@ -83,6 +83,7 @@ type fakeResourceClientForUnstructured struct {
 	patchErr    error
 	createCount int
 	patchCount  int
+	patchOpts   []metav1.PatchOptions
 }
 
 func (c *fakeResourceClientForUnstructured) Get(_ context.Context, _ string, _ metav1.GetOptions) (*unstructured.Unstructured, error) {
@@ -103,15 +104,16 @@ func (c *fakeResourceClientForUnstructured) Create(_ context.Context, obj *unstr
 	return obj, nil
 }
 
-func (c *fakeResourceClientForUnstructured) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, _ metav1.PatchOptions) (*unstructured.Unstructured, error) {
+func (c *fakeResourceClientForUnstructured) Patch(_ context.Context, _ string, _ types.PatchType, _ []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
 	c.patchCount++
+	c.patchOpts = append(c.patchOpts, opts)
 	if c.patchErr != nil {
 		return nil, c.patchErr
 	}
 	return c.existing, nil
 }
 
-func TestCreateUnstructured(t *testing.T) {
+func TestCreateUnstructuredUsesStableSSAFieldManager(t *testing.T) {
 	t.Parallel()
 
 	fakeClient := &fakeResourceClientForUnstructured{}
@@ -123,7 +125,10 @@ func TestCreateUnstructured(t *testing.T) {
 
 	err := CreateUnstructured(context.Background(), fakeClient, u, "IngressRoute")
 	require.NoError(t, err)
-	require.Equal(t, 1, fakeClient.createCount)
+	require.Zero(t, fakeClient.createCount)
+	require.Equal(t, 1, fakeClient.patchCount)
+	require.Equal(t, FieldManager, fakeClient.patchOpts[0].FieldManager)
+	require.Nil(t, fakeClient.patchOpts[0].Force)
 }
 
 func TestCreateUnstructuredWithFieldValidation(t *testing.T) {
@@ -138,7 +143,85 @@ func TestCreateUnstructuredWithFieldValidation(t *testing.T) {
 
 	err := CreateUnstructured(context.Background(), fakeClient, u, "TraefikService")
 	require.NoError(t, err)
-	require.Equal(t, 1, fakeClient.createCount)
+	require.Zero(t, fakeClient.createCount)
+	require.Equal(t, 1, fakeClient.patchCount)
+	require.Equal(t, metav1.FieldValidationIgnore, fakeClient.patchOpts[0].FieldValidation)
+}
+
+func managedObjectWithSpecOwner(manager string, operation metav1.ManagedFieldsOperationType) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "test"},
+		"spec":     map[string]interface{}{"name": "old"},
+	}}
+	u.SetLabels(map[string]string{managedLabelKey: managedLabelValue})
+	u.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    manager,
+		Operation:  operation,
+		APIVersion: TraefikAPIVersion,
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:name":{}}}`)},
+	}})
+	return u
+}
+
+func desiredManagedObject() map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": TraefikAPIVersion,
+		"kind":       KindTraefikService,
+		"metadata": map[string]interface{}{
+			"name":   "test",
+			"labels": map[string]interface{}{managedLabelKey: managedLabelValue},
+		},
+		"spec": map[string]interface{}{"name": "new"},
+	}
+}
+
+func TestSubsequentSpecChangeUsesSSAWithoutForce(t *testing.T) {
+	t.Parallel()
+	existing := managedObjectWithSpecOwner(FieldManager, metav1.ManagedFieldsOperationApply)
+	fakeClient := &fakeResourceClientForUnstructured{existing: existing}
+
+	err := PatchUnstructured(context.Background(), fakeClient, "test", desiredManagedObject(), existing, KindTraefikService, PatchConfig{MetadataConfig: defaultMetadataConfig()})
+	require.NoError(t, err)
+	require.Equal(t, FieldManager, fakeClient.patchOpts[0].FieldManager)
+	require.Nil(t, fakeClient.patchOpts[0].Force)
+}
+
+func TestLegacyControllerManagedSpecIsSafelyAdopted(t *testing.T) {
+	t.Parallel()
+	existing := managedObjectWithSpecOwner("controller", metav1.ManagedFieldsOperationUpdate)
+	fakeClient := &fakeResourceClientForUnstructured{existing: existing}
+
+	err := PatchUnstructured(context.Background(), fakeClient, "test", desiredManagedObject(), existing, KindTraefikService, PatchConfig{MetadataConfig: defaultMetadataConfig()})
+	require.NoError(t, err)
+	require.NotNil(t, fakeClient.patchOpts[0].Force)
+	require.True(t, *fakeClient.patchOpts[0].Force)
+}
+
+func TestExternalSpecOwnershipIsNotStolen(t *testing.T) {
+	t.Parallel()
+	existing := managedObjectWithSpecOwner("external-operator", metav1.ManagedFieldsOperationApply)
+	fakeClient := &fakeResourceClientForUnstructured{existing: existing}
+
+	err := PatchUnstructured(context.Background(), fakeClient, "test", desiredManagedObject(), existing, KindTraefikService, PatchConfig{MetadataConfig: defaultMetadataConfig()})
+	require.NoError(t, err)
+	require.Nil(t, fakeClient.patchOpts[0].Force)
+}
+
+func TestRepeatedReconcileUsesSameSSAOwnership(t *testing.T) {
+	t.Parallel()
+	existing := managedObjectWithSpecOwner(FieldManager, metav1.ManagedFieldsOperationApply)
+	fakeClient := &fakeResourceClientForUnstructured{existing: existing}
+
+	for range 2 {
+		err := PatchUnstructured(context.Background(), fakeClient, "test", desiredManagedObject(), existing, KindTraefikService, PatchConfig{MetadataConfig: defaultMetadataConfig()})
+		require.NoError(t, err)
+	}
+	require.Equal(t, 2, fakeClient.patchCount)
+	for _, opts := range fakeClient.patchOpts {
+		require.Equal(t, FieldManager, opts.FieldManager)
+		require.Nil(t, opts.Force)
+	}
 }
 
 func TestPatchUnstructured(t *testing.T) {

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -211,11 +211,13 @@ func (c *Controller) applyDesiredObjects(ctx context.Context, dyn dynamic.Interf
 		SSAForce:  c.cfg.SSAForce,
 	}
 	metaCfg := apply.MetadataConfig{
-		ManagedLabelKey:   c.cfg.ManagedLabelKey,
-		ManagedLabelValue: c.cfg.ManagedLabelValue,
-		ManagedAnnoKey:    c.cfg.ManagedAnnoKey,
-		ManagedAnnoValue:  c.cfg.ManagedAnnoValue,
-		IngressClass:      c.cfg.IngressClass,
+		ManagedLabelKey:           c.cfg.ManagedLabelKey,
+		ManagedLabelValue:         c.cfg.ManagedLabelValue,
+		TraefikInstanceLabelKey:   c.cfg.TraefikInstanceLabelKey,
+		TraefikInstanceLabelValue: c.cfg.TraefikInstanceLabelValue,
+		ManagedAnnoKey:            c.cfg.ManagedAnnoKey,
+		ManagedAnnoValue:          c.cfg.ManagedAnnoValue,
+		IngressClass:              c.cfg.IngressClass,
 	}
 	for name := range objects {
 		if err := ops.Apply(ctx, name, objects[name], metaCfg); err != nil {

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -188,14 +188,16 @@ func (c *Controller) applyIngressRoute(ctx context.Context, resIfc resources.Res
 		return nil
 	}
 	ops := &apply.IngressRouteOps{
-		ResIfc:            resIfc,
-		Namespace:         c.cfg.Namespace,
-		ManagedLabelKey:   c.cfg.ManagedLabelKey,
-		ManagedLabelValue: c.cfg.ManagedLabelValue,
-		ManagedAnnoKey:    c.cfg.ManagedAnnoKey,
-		ManagedAnnoValue:  c.cfg.ManagedAnnoValue,
-		IngressClass:      c.cfg.IngressClass,
-		ReadOnly:          c.cfg.ReadOnly,
+		ResIfc:                    resIfc,
+		Namespace:                 c.cfg.Namespace,
+		ManagedLabelKey:           c.cfg.ManagedLabelKey,
+		ManagedLabelValue:         c.cfg.ManagedLabelValue,
+		TraefikInstanceLabelKey:   c.cfg.TraefikInstanceLabelKey,
+		TraefikInstanceLabelValue: c.cfg.TraefikInstanceLabelValue,
+		ManagedAnnoKey:            c.cfg.ManagedAnnoKey,
+		ManagedAnnoValue:          c.cfg.ManagedAnnoValue,
+		IngressClass:              c.cfg.IngressClass,
+		ReadOnly:                  c.cfg.ReadOnly,
 	}
 	return ops.Apply(ctx, name, u)
 }
@@ -437,14 +439,16 @@ func (c *Controller) applyProtocolSlices(ctx context.Context, slices []*discover
 func (c *Controller) applyProtocolIngressRoutes(ctx context.Context, routes []map[string]interface{}, ingressRouteGVR schema.GroupVersionResource, kind string) error {
 	resIfc := resources.AdaptResource(c.dyn.Resource(ingressRouteGVR).Namespace(c.cfg.Namespace))
 	ops := &apply.IngressRouteOps{
-		ResIfc:            resIfc,
-		Namespace:         c.cfg.Namespace,
-		ManagedLabelKey:   c.cfg.ManagedLabelKey,
-		ManagedLabelValue: c.cfg.ManagedLabelValue,
-		ManagedAnnoKey:    c.cfg.ManagedAnnoKey,
-		ManagedAnnoValue:  c.cfg.ManagedAnnoValue,
-		IngressClass:      c.cfg.IngressClass,
-		ReadOnly:          c.cfg.ReadOnly,
+		ResIfc:                    resIfc,
+		Namespace:                 c.cfg.Namespace,
+		ManagedLabelKey:           c.cfg.ManagedLabelKey,
+		ManagedLabelValue:         c.cfg.ManagedLabelValue,
+		TraefikInstanceLabelKey:   c.cfg.TraefikInstanceLabelKey,
+		TraefikInstanceLabelValue: c.cfg.TraefikInstanceLabelValue,
+		ManagedAnnoKey:            c.cfg.ManagedAnnoKey,
+		ManagedAnnoValue:          c.cfg.ManagedAnnoValue,
+		IngressClass:              c.cfg.IngressClass,
+		ReadOnly:                  c.cfg.ReadOnly,
 	}
 	for _, m := range routes {
 		if err := ops.ApplySingle(ctx, m, kind); err != nil {

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -290,11 +290,26 @@ func deleteImmediate(ctx context.Context, resIfc resources.ResourceClient, name 
 }
 
 func (c *Controller) reconcileServices(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, services map[string]json.RawMessage) error {
-	processed := protocol.ProcessServices(c.cfg, services)
+	processed, kubeServices, endpointSlices, err := protocol.ProcessHTTPServices(c.cfg, services, c.cfg.Namespace)
+	if err != nil {
+		return err
+	}
+	if err := c.applyProtocolServices(ctx, kubeServices); err != nil {
+		return err
+	}
+	if err := c.applyProtocolSlices(ctx, endpointSlices); err != nil {
+		return err
+	}
 	if err := c.applyDesiredObjects(ctx, dyn, gvr, processed); err != nil {
 		return err
 	}
-	return c.gcStaleObjects(ctx, dyn, gvr, processed, "TraefikService")
+	if err := c.gcStaleObjects(ctx, dyn, gvr, processed, "TraefikService"); err != nil {
+		return err
+	}
+	if err := c.gcStaleCoreServices(ctx, desiredServiceNames(kubeServices), "http"); err != nil {
+		return err
+	}
+	return c.gcStaleEndpointSlices(ctx, desiredEndpointSliceNames(endpointSlices), "http")
 }
 
 func (c *Controller) reconcileServersTransports(ctx context.Context, dyn dynamic.Interface, gvr schema.GroupVersionResource, transports map[string]json.RawMessage) error {
@@ -343,10 +358,10 @@ func (c *Controller) reconcileTCP(ctx context.Context, cfg *traefikconfig.Config
 	if err := c.gcStaleObjects(ctx, c.dyn, c.gvrIngressRouteTCP, desiredRoutes, "IngressRouteTCP"); err != nil {
 		return err
 	}
-	if err := c.gcStaleCoreServices(ctx, desiredSvc); err != nil {
+	if err := c.gcStaleCoreServices(ctx, desiredSvc, "tcp"); err != nil {
 		return err
 	}
-	if err := c.gcStaleEndpointSlices(ctx, desiredSlices); err != nil {
+	if err := c.gcStaleEndpointSlices(ctx, desiredSlices, "tcp"); err != nil {
 		return err
 	}
 	return nil
@@ -385,10 +400,10 @@ func (c *Controller) reconcileUDP(ctx context.Context, cfg *traefikconfig.Config
 	if err := c.gcStaleObjects(ctx, c.dyn, c.gvrIngressRouteUDP, desiredRoutes, "IngressRouteUDP"); err != nil {
 		return err
 	}
-	if err := c.gcStaleCoreServices(ctx, desiredSvc); err != nil {
+	if err := c.gcStaleCoreServices(ctx, desiredSvc, "udp"); err != nil {
 		return err
 	}
-	if err := c.gcStaleEndpointSlices(ctx, desiredSlices); err != nil {
+	if err := c.gcStaleEndpointSlices(ctx, desiredSlices, "udp"); err != nil {
 		return err
 	}
 	return nil
@@ -529,9 +544,26 @@ func (c *Controller) ensureManagedEndpointSliceMeta(es *discoveryv1.EndpointSlic
 	es.Annotations[c.cfg.ManagedAnnoKey] = c.cfg.ManagedAnnoValue
 }
 
-func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string]json.RawMessage) error {
+func desiredServiceNames(services []*corev1.Service) map[string]json.RawMessage {
+	desired := make(map[string]json.RawMessage, len(services))
+	for _, service := range services {
+		desired[service.Name] = json.RawMessage("{}")
+	}
+	return desired
+}
+
+func desiredEndpointSliceNames(endpointSlices []*discoveryv1.EndpointSlice) map[string]json.RawMessage {
+	desired := make(map[string]json.RawMessage, len(endpointSlices))
+	for _, endpointSlice := range endpointSlices {
+		desired[endpointSlice.Name] = json.RawMessage("{}")
+	}
+	return desired
+}
+
+func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string]json.RawMessage, protocolName string) error {
 	cli := c.kube.CoreV1().Services(c.cfg.Namespace)
-	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue)})
+	selector := fmt.Sprintf("%s=%s,%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue, protocol.ArtifactProtocolLabel, protocolName)
+	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return err
 	}
@@ -548,9 +580,10 @@ func (c *Controller) gcStaleCoreServices(ctx context.Context, desired map[string
 	return nil
 }
 
-func (c *Controller) gcStaleEndpointSlices(ctx context.Context, desired map[string]json.RawMessage) error {
+func (c *Controller) gcStaleEndpointSlices(ctx context.Context, desired map[string]json.RawMessage, protocolName string) error {
 	cli := c.kube.DiscoveryV1().EndpointSlices(c.cfg.Namespace)
-	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue)})
+	selector := fmt.Sprintf("%s=%s,%s=%s", c.cfg.ManagedLabelKey, c.cfg.ManagedLabelValue, protocol.ArtifactProtocolLabel, protocolName)
+	list, err := cli.List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return err
 	}

--- a/internal/controller/apply_test.go
+++ b/internal/controller/apply_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 
 	"pangolin-kube-controller/internal/config"
+	"pangolin-kube-controller/internal/testutil"
 	traefikconfig "pangolin-kube-controller/internal/transform/config"
 )
 
@@ -92,6 +93,7 @@ func TestApplyDesiredObjectsPropagatesConfiguredTraefikIdentity(t *testing.T) {
 		}] = item.kind
 	}
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	testutil.EnableSSAUpsert(dyn)
 	c := NewController(&config.Config{
 		Namespace:                 namespace,
 		ManagedLabelKey:           "app.kubernetes.io/managed-by",

--- a/internal/controller/apply_test.go
+++ b/internal/controller/apply_test.go
@@ -1,8 +1,17 @@
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+
+	"pangolin-kube-controller/internal/config"
+	traefikconfig "pangolin-kube-controller/internal/transform/config"
 )
 
 func TestBuildDesiredSet(t *testing.T) {
@@ -51,6 +60,66 @@ func TestBuildDesiredSet(t *testing.T) {
 				if _, ok := got[name]; !ok {
 					t.Errorf("buildDesiredSet() missing key %q", name)
 				}
+			}
+		})
+	}
+}
+
+func TestApplyDesiredObjectsPropagatesConfiguredTraefikIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace     = "blue-ocean"
+		identityKey   = "routing.example.com/traefik-instance"
+		identityValue = "blue-ocean-edge"
+	)
+	resources := []struct {
+		resource string
+		kind     string
+	}{
+		{resource: "middlewares", kind: "MiddlewareList"},
+		{resource: "ingressroutes", kind: "IngressRouteList"},
+		{resource: "traefikservices", kind: "TraefikServiceList"},
+		{resource: "serverstransports", kind: "ServersTransportList"},
+		{resource: "ingressroutetcps", kind: "IngressRouteTCPList"},
+		{resource: "ingressrouteudps", kind: "IngressRouteUDPList"},
+		{resource: "serverstransporttcps", kind: "ServersTransportTCPList"},
+	}
+	listKinds := make(map[schema.GroupVersionResource]string, len(resources))
+	for _, item := range resources {
+		listKinds[schema.GroupVersionResource{
+			Group: traefikconfig.Group, Version: traefikconfig.Version, Resource: item.resource,
+		}] = item.kind
+	}
+	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), listKinds)
+	c := NewController(&config.Config{
+		Namespace:                 namespace,
+		ManagedLabelKey:           "app.kubernetes.io/managed-by",
+		ManagedLabelValue:         "pangolin-kube-controller",
+		ManagedAnnoKey:            "pangolin.io/managed-by",
+		ManagedAnnoValue:          "pangolin-kube-controller",
+		TraefikInstanceLabelKey:   identityKey,
+		TraefikInstanceLabelValue: identityValue,
+	}, dyn, nil, nil)
+
+	for _, item := range resources {
+		t.Run(item.resource, func(t *testing.T) {
+			gvr := schema.GroupVersionResource{
+				Group: traefikconfig.Group, Version: traefikconfig.Version, Resource: item.resource,
+			}
+			name := "generated-" + item.resource
+			err := c.applyDesiredObjects(context.Background(), dyn, gvr, map[string]json.RawMessage{
+				name: json.RawMessage(`{}`),
+			})
+			if err != nil {
+				t.Fatalf("applyDesiredObjects() error = %v", err)
+			}
+			got, err := dyn.Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get generated %s: %v", item.resource, err)
+			}
+			if got.GetLabels()[identityKey] != identityValue {
+				t.Fatalf("instance label = %q, want %q", got.GetLabels()[identityKey], identityValue)
 			}
 		})
 	}

--- a/internal/kube/labels/resolver_test.go
+++ b/internal/kube/labels/resolver_test.go
@@ -208,6 +208,25 @@ func TestResolveInstanceLabelConfiguredValidation(t *testing.T) {
 	})
 }
 
+func TestResolveInstanceLabelExplicitIdentityBypassesAutodetection(t *testing.T) {
+	t.Parallel()
+
+	const configuredIdentity = "edge-controller-blue"
+	cfg := &config.Config{
+		TraefikInstanceLabelKey:   "routing.example.com/instance",
+		TraefikInstanceLabelValue: configuredIdentity,
+		IngressClass:              "edge-traefik",
+	}
+	// A nil Kubernetes client makes any attempted IngressClass autodetection
+	// fail. Explicit identity must return before consulting cluster state.
+	if err := ResolveInstanceLabel(context.Background(), nil, cfg, nil); err != nil {
+		t.Fatalf("explicit identity unexpectedly attempted autodetection: %v", err)
+	}
+	if cfg.TraefikInstanceLabelValue != configuredIdentity {
+		t.Fatalf("TraefikInstanceLabelValue = %q, want %q", cfg.TraefikInstanceLabelValue, configuredIdentity)
+	}
+}
+
 func TestMonitorEmptyConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testutil/ssa.go
+++ b/internal/testutil/ssa.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// EnableSSAUpsert teaches client-go's fake dynamic client the API server's
+// create-or-update semantics for server-side apply patches.
+func EnableSSAUpsert(client *fake.FakeDynamicClient) {
+	client.PrependReactor("patch", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		patchAction, ok := action.(k8stesting.PatchAction)
+		if !ok || patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(patchAction.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		obj.SetNamespace(action.GetNamespace())
+		gvr := action.GetResource()
+		_, err := client.Tracker().Get(gvr, action.GetNamespace(), obj.GetName())
+		switch {
+		case errors.IsNotFound(err):
+			err = client.Tracker().Create(gvr, obj, action.GetNamespace())
+		case err == nil:
+			err = client.Tracker().Update(gvr, obj, action.GetNamespace())
+		}
+		return true, obj, err
+	})
+}

--- a/internal/transform/protocol/http_conversion.go
+++ b/internal/transform/protocol/http_conversion.go
@@ -8,9 +8,15 @@ import (
 	"strings"
 
 	logrus "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"pangolin-kube-controller/internal/config"
+	"pangolin-kube-controller/internal/transform/sanitize"
 )
+
+// ArtifactProtocolLabel scopes generated Kubernetes resources by protocol.
+const ArtifactProtocolLabel = "pangolin-kube-controller/protocol"
 
 type kubeServiceTarget struct {
 	name      string
@@ -21,39 +27,88 @@ type kubeServiceTarget struct {
 
 // ProcessServices rewrites TraefikService specs for load balancer conversions and logging.
 func ProcessServices(cfg *config.Config, services map[string]json.RawMessage) map[string]json.RawMessage {
-	if services == nil {
-		return nil
-	}
-	out := make(map[string]json.RawMessage, len(services))
-	for name, raw := range services {
-		out[name] = processSingleService(cfg, name, raw)
-	}
-	return out
+	processed, _, _, _ := ProcessHTTPServices(cfg, services, "")
+	return processed
 }
 
 func processSingleService(cfg *config.Config, name string, raw json.RawMessage) json.RawMessage {
+	processed, _, _, _ := processSingleHTTPService(cfg, "", name, raw)
+	return processed
+}
+
+// ProcessHTTPServices rewrites HTTP service specs and builds Kubernetes
+// artifacts for load balancers whose servers are not Kubernetes Services.
+func ProcessHTTPServices(cfg *config.Config, services map[string]json.RawMessage, namespace string) (map[string]json.RawMessage, []*corev1.Service, []*discoveryv1.EndpointSlice, error) {
+	if services == nil {
+		return nil, nil, nil, nil
+	}
+	out := make(map[string]json.RawMessage, len(services))
+	var kubeServices []*corev1.Service
+	var endpointSlices []*discoveryv1.EndpointSlice
+	for name, raw := range services {
+		processed, svc, endpointSlice, err := processSingleHTTPService(cfg, namespace, name, raw)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("process HTTP service %s: %w", name, err)
+		}
+		out[name] = processed
+		if svc != nil {
+			kubeServices = append(kubeServices, svc)
+			endpointSlices = append(endpointSlices, endpointSlice)
+		}
+	}
+	return out, kubeServices, endpointSlices, nil
+}
+
+func processSingleHTTPService(cfg *config.Config, namespace, name string, raw json.RawMessage) (json.RawMessage, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	trim := strings.TrimSpace(string(raw))
 	if trim != "" && trim != "{}" {
-		return processNonEmptyService(name, raw)
+		return processNonEmptyHTTPService(namespace, name, raw)
 	}
-	return processEmptyService(cfg, name, raw)
+	return processEmptyService(cfg, name, raw), nil, nil, nil
 }
 
 func processNonEmptyService(name string, raw json.RawMessage) json.RawMessage {
+	processed, _, _, _ := processNonEmptyHTTPService("", name, raw)
+	return processed
+}
+
+func processNonEmptyHTTPService(namespace, name string, raw json.RawMessage) (json.RawMessage, *corev1.Service, *discoveryv1.EndpointSlice, error) {
 	var spec map[string]interface{}
-	if err := json.Unmarshal(raw, &spec); err == nil {
-		if target, ok := convertLoadBalancerToK8sService(spec); ok {
-			if b, err := json.Marshal(spec); err == nil {
-				raw = b
-				logrus.Infof("TraefikService %s converted to Kubernetes Service %s/%s port=%d scheme=%s", name, target.namespace, target.name, target.port, target.scheme)
-			} else {
-				logrus.Warnf("TraefikService %s conversion marshal failed: %v", name, err)
-			}
-		} else if urls := extractServiceURLs(spec); len(urls) > 0 {
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return raw, nil, nil, nil
+	}
+	if target, ok := convertLoadBalancerToK8sService(spec); ok {
+		converted, err := json.Marshal(spec)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("marshal Kubernetes Service reference: %w", err)
+		}
+		logrus.Infof("TraefikService %s converted to Kubernetes Service %s/%s port=%d scheme=%s", name, target.namespace, target.name, target.port, target.scheme)
+		return converted, nil, nil, nil
+	}
+	target, ok := parseExternalServiceTargets(spec)
+	if !ok || namespace == "" {
+		if urls := extractServiceURLs(spec); len(urls) > 0 {
 			logrus.Infof("TraefikService %s servers=%v", name, urls)
 		}
+		return raw, nil, nil, nil
 	}
-	return raw
+	kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", name, target.port))
+	rewriteAsKubeService(spec, kubeName, namespace, target.port, target.scheme, target.serviceOptions)
+	converted, err := json.Marshal(spec)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("marshal external Service reference: %w", err)
+	}
+	svc := buildHeadlessService(namespace, kubeName, int32(target.port), corev1.ProtocolTCP)
+	svc.Labels = map[string]string{ArtifactProtocolLabel: "http"}
+	endpointSlice, err := buildEndpointSlice(namespace, kubeName, int32(target.port), target.hosts, corev1.ProtocolTCP)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	endpointSlice.Labels = map[string]string{
+		ArtifactProtocolLabel:        "http",
+		discoveryv1.LabelServiceName: kubeName,
+	}
+	return converted, svc, endpointSlice, nil
 }
 
 func processEmptyService(cfg *config.Config, name string, raw json.RawMessage) json.RawMessage {
@@ -118,18 +173,88 @@ func convertLoadBalancerToK8sService(spec map[string]interface{}) (*kubeServiceT
 	if !ok || target == nil {
 		return nil, false
 	}
-	serviceEntry := map[string]interface{}{
-		"name":      target.name,
-		"namespace": target.namespace,
-		"kind":      "Service",
-		"port":      target.port,
+	rewriteAsKubeService(spec, target.name, target.namespace, target.port, target.scheme, nil)
+	return target, true
+}
+
+type externalServiceTarget struct {
+	hosts          []string
+	port           int
+	scheme         string
+	serviceOptions map[string]interface{}
+}
+
+func parseExternalServiceTargets(spec map[string]interface{}) (*externalServiceTarget, bool) {
+	lb, ok := spec["loadBalancer"].(map[string]interface{})
+	if !ok {
+		return nil, false
 	}
-	if target.scheme == "https" {
+	servers, ok := lb["servers"].([]interface{})
+	if !ok {
+		return nil, false
+	}
+	serviceOptions := make(map[string]interface{}, len(lb)-1)
+	for key, value := range lb {
+		if key != "servers" {
+			serviceOptions[key] = value
+		}
+	}
+	var target *externalServiceTarget
+	for _, server := range servers {
+		serverMap, ok := server.(map[string]interface{})
+		if !ok || len(serverMap) != 1 {
+			return nil, false
+		}
+		rawURL, ok := serverMap["url"].(string)
+		if !ok {
+			return nil, false
+		}
+		parsed, err := netURLParse(rawURL)
+		if err != nil || validateExternalServiceURL(parsed, rawURL) != nil {
+			return nil, false
+		}
+		port := derivePort(parsed)
+		if target == nil {
+			target = &externalServiceTarget{port: port, scheme: parsed.Scheme, serviceOptions: serviceOptions}
+		} else if target.port != port || target.scheme != parsed.Scheme {
+			return nil, false
+		}
+		target.hosts = append(target.hosts, parsed.Hostname())
+	}
+	return target, target != nil
+}
+
+func validateExternalServiceURL(parsed *url.URL, raw string) error {
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported scheme %s", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("missing host")
+	}
+	if (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" {
+		return fmt.Errorf("unsupported path or query components in %s", raw)
+	}
+	if strings.Contains(parsed.Hostname(), ".svc.") || strings.HasSuffix(parsed.Hostname(), ".svc") {
+		return fmt.Errorf("target is a Kubernetes Service")
+	}
+	return nil
+}
+
+func rewriteAsKubeService(spec map[string]interface{}, name, namespace string, port int, scheme string, options map[string]interface{}) {
+	serviceEntry := map[string]interface{}{
+		"name":      name,
+		"namespace": namespace,
+		"kind":      "Service",
+		"port":      port,
+	}
+	if scheme == "https" {
 		serviceEntry["scheme"] = "https"
+	}
+	for key, value := range options {
+		serviceEntry[key] = value
 	}
 	spec["weighted"] = map[string]interface{}{"services": []interface{}{serviceEntry}}
 	delete(spec, "loadBalancer")
-	return target, true
 }
 
 // extractLBServers validates top-level loadBalancer shape & returns servers list.

--- a/internal/transform/protocol/process_services_test.go
+++ b/internal/transform/protocol/process_services_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
 
 	"pangolin-kube-controller/internal/config"
 )
@@ -190,6 +191,50 @@ func TestProcessServicesKubeServiceConversion(t *testing.T) {
 	// After conversion, loadBalancer should be replaced by weighted.
 	require.Contains(t, spec, "weighted")
 	require.NotContains(t, spec, "loadBalancer")
+}
+
+func TestProcessHTTPServicesExternalTunnelTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName = "svc"
+		port        = 8443
+		kubeName    = "svc-8443"
+	)
+	services := map[string]json.RawMessage{
+		serviceName: json.RawMessage(`{"loadBalancer":{"servers":[{"url":"https://192.0.2.1:8443"}],"serversTransport":"transport","sticky":{"cookie":{"name":"sticky"}}}}`),
+	}
+
+	processed, kubeServices, endpointSlices, err := ProcessHTTPServices(&config.Config{}, services, "traefik")
+	require.NoError(t, err)
+	require.Len(t, kubeServices, 1)
+	require.Len(t, endpointSlices, 1)
+
+	service := kubeServices[0]
+	require.Equal(t, kubeName, service.Name)
+	require.Equal(t, "traefik", service.Namespace)
+	require.Equal(t, "None", service.Spec.ClusterIP)
+	require.EqualValues(t, port, service.Spec.Ports[0].Port)
+	require.Equal(t, "http", service.Labels[ArtifactProtocolLabel])
+
+	endpointSlice := endpointSlices[0]
+	require.Equal(t, discoveryv1.AddressTypeIPv4, endpointSlice.AddressType)
+	require.Equal(t, []string{"192.0.2.1"}, endpointSlice.Endpoints[0].Addresses)
+	require.Equal(t, kubeName, endpointSlice.Labels[discoveryv1.LabelServiceName])
+
+	var spec map[string]interface{}
+	require.NoError(t, json.Unmarshal(processed[serviceName], &spec))
+	require.NotContains(t, spec, "loadBalancer")
+	weighted := spec["weighted"].(map[string]interface{})
+	entries := weighted["services"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+	require.Equal(t, kubeName, entry["name"])
+	require.Equal(t, "traefik", entry["namespace"])
+	require.Equal(t, "Service", entry["kind"])
+	require.Equal(t, "https", entry["scheme"])
+	require.Equal(t, "transport", entry["serversTransport"])
+	require.Contains(t, entry, "sticky")
+	require.EqualValues(t, port, entry["port"])
 }
 
 func TestProcessServicesPreservesNonConvertible(t *testing.T) {

--- a/internal/transform/protocol/tcp_udp.go
+++ b/internal/transform/protocol/tcp_udp.go
@@ -76,11 +76,14 @@ func buildTCPKubeArtifacts(namespace string, keys []string, info map[string]tcpS
 		meta := info[dyn]
 		kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", dyn, meta.port))
 		nameMap[dyn] = kubeName
-		svcs = append(svcs, buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolTCP))
+		svc := buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolTCP)
+		svc.Labels = map[string]string{ArtifactProtocolLabel: "tcp"}
+		svcs = append(svcs, svc)
 		eps, e := buildEndpointSlice(namespace, kubeName, meta.port, meta.hosts, corev1.ProtocolTCP)
 		if e != nil {
 			return nil, nil, nil, e
 		}
+		eps.Labels = map[string]string{ArtifactProtocolLabel: "tcp", discoveryv1.LabelServiceName: kubeName}
 		slices = append(slices, eps)
 	}
 	return nameMap, svcs, slices, nil
@@ -219,11 +222,14 @@ func buildUDPKubeArtifacts(namespace string, keys []string, info map[string]udpS
 		meta := info[dyn]
 		kubeName := sanitize.SanitizeResourceName(fmt.Sprintf("%s-%d", dyn, meta.port))
 		nameMap[dyn] = kubeName
-		svcs = append(svcs, buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolUDP))
+		svc := buildHeadlessService(namespace, kubeName, meta.port, corev1.ProtocolUDP)
+		svc.Labels = map[string]string{ArtifactProtocolLabel: "udp"}
+		svcs = append(svcs, svc)
 		eps, e := buildEndpointSlice(namespace, kubeName, meta.port, meta.hosts, corev1.ProtocolUDP)
 		if e != nil {
 			return nil, nil, nil, e
 		}
+		eps.Labels = map[string]string{ArtifactProtocolLabel: "udp", discoveryv1.LabelServiceName: kubeName}
 		slices = append(slices, eps)
 	}
 	return nameMap, svcs, slices, nil

--- a/test/e2e/offline_e2e_test.go
+++ b/test/e2e/offline_e2e_test.go
@@ -44,6 +44,7 @@ func TestOfflineE2EExtendedHTTPTCPUDP(t *testing.T) {
 		{Group: traefikGroupLocal, Version: "v1alpha1", Resource: "serverstransporttcps"}: "ServersTransportTCPList",
 	}
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(sch, listKinds)
+	tst.EnableSSAUpsert(dyn)
 	kube := fakekube.NewClientset()
 
 	cfg := config.LoadFromEnv()


### PR DESCRIPTION
## Summary

- reconcile external HTTP load-balancer targets through generated Kubernetes Services and EndpointSlices instead of unsupported TraefikService loadBalancer fields
- use server-side apply from initial creation with the stable pangolin-kube-controller field manager
- safely adopt legacy controller Update spec ownership only for controller-managed resources
- propagate configured Traefik instance identity through generic and specialized IngressRoute, TCP, and UDP paths
- preserve unrelated metadata and repair missing controller-owned identity in place

## Production compatibility

This complete set is required for current Traefik CRD schemas: external HTTP targets must be converted before SSA, while generated Traefik resources retain stable ownership and the configured production instance identity.

## Validation

- go test ./...
- go vet ./...
- production validation covers controller readiness, clean reconciliation, external HTTP targets, SSA ownership, instance-label persistence, CrowdSec, Bitwarden, Forgejo, and codex-lb